### PR TITLE
optimization in git clone using --depth

### DIFF
--- a/Modules/matplotlib-1.1.1/matplotlib-1.1.1/doc/devel/gitwash/following_latest.rst
+++ b/Modules/matplotlib-1.1.1/matplotlib-1.1.1/doc/devel/gitwash/following_latest.rst
@@ -18,7 +18,7 @@ Get the local copy of the code
 
 From the command line::
 
-   git clone git://github.com/matplotlib/matplotlib.git
+   git clone --depth 1 git://github.com/matplotlib/matplotlib.git
 
 You now have a copy of the code tree in the new ``matplotlib`` directory.
 

--- a/Modules/matplotlib-1.1.1/matplotlib-1.1.1/doc/faq/installing_faq.rst
+++ b/Modules/matplotlib-1.1.1/matplotlib-1.1.1/doc/faq/installing_faq.rst
@@ -107,11 +107,11 @@ Source install from git
 
 Clone the main source using one of::
 
-   git clone git@github.com:matplotlib/matplotlib.git
+   git clone --depth 1 git@github.com:matplotlib/matplotlib.git
 
 or::
 
-   git clone git://github.com/matplotlib/matplotlib.git
+   git clone --depth 1 git://github.com/matplotlib/matplotlib.git
 
 and build and install as usual with::
 
@@ -315,7 +315,7 @@ previous version of MPL was installed (Looks something like
    PREFIX=$HOME
    #branch="release"
    branch="master"
-   git clone git://github.com/matplotlib/matplotlib.git
+   git clone --depth 1 git://github.com/matplotlib/matplotlib.git
    cd matplotlib
    if [ $branch = "release" ]
        then

--- a/Modules/matplotlib-1.1.1/matplotlib-1.1.1/doc/mpl_examples/misc/sample_data_test.py
+++ b/Modules/matplotlib-1.1.1/matplotlib-1.1.1/doc/mpl_examples/misc/sample_data_test.py
@@ -1,7 +1,7 @@
 """
 Demonstrate how get_sample_data works with git revisions in the data.
 
-    git clone git@github.com/matplotlib/sample_data.git
+    git clone --depth 1 git@github.com/matplotlib/sample_data.git
 
 and edit testdata.csv to add a new row.  After committing the changes,
 when you rerun this script you will get the updated data (and the new

--- a/Modules/matplotlib-1.1.1/matplotlib-1.1.1/examples/misc/sample_data_test.py
+++ b/Modules/matplotlib-1.1.1/matplotlib-1.1.1/examples/misc/sample_data_test.py
@@ -1,7 +1,7 @@
 """
 Demonstrate how get_sample_data works with git revisions in the data.
 
-    git clone git@github.com/matplotlib/sample_data.git
+    git clone --depth 1 git@github.com/matplotlib/sample_data.git
 
 and edit testdata.csv to add a new row.  After committing the changes,
 when you rerun this script you will get the updated data (and the new

--- a/Modules/matplotlib-1.1.1/matplotlib-1.1.1/lib/matplotlib/cbook.py
+++ b/Modules/matplotlib-1.1.1/matplotlib-1.1.1/lib/matplotlib/cbook.py
@@ -666,7 +666,7 @@ def get_sample_data(fname, asfileobj=True):
     To add a datafile to this directory, you need to check out
     sample_data from matplotlib git::
 
-      git clone git@github.com:matplotlib/sample_data
+      git clone --depth 1 git@github.com:matplotlib/sample_data
 
     and git add the data file you want to support.  This is primarily
     intended for use in mpl examples that need custom data.

--- a/Modules/matplotlib-1.1.1/matplotlib-1.1.1/lib/mpl_examples/misc/sample_data_test.py
+++ b/Modules/matplotlib-1.1.1/matplotlib-1.1.1/lib/mpl_examples/misc/sample_data_test.py
@@ -1,7 +1,7 @@
 """
 Demonstrate how get_sample_data works with git revisions in the data.
 
-    git clone git@github.com/matplotlib/sample_data.git
+    git clone --depth 1 git@github.com/matplotlib/sample_data.git
 
 and edit testdata.csv to add a new row.  After committing the changes,
 when you rerun this script you will get the updated data (and the new

--- a/Modules/matplotlib-1.3.1/matplotlib-1.3.1/doc/devel/gitwash/following_latest.rst
+++ b/Modules/matplotlib-1.3.1/matplotlib-1.3.1/doc/devel/gitwash/following_latest.rst
@@ -18,7 +18,7 @@ Get the local copy of the code
 
 From the command line::
 
-   git clone git://github.com/matplotlib/matplotlib.git
+   git clone --depth 1 git://github.com/matplotlib/matplotlib.git
 
 You now have a copy of the code tree in the new ``matplotlib`` directory.
 

--- a/Modules/matplotlib-1.3.1/matplotlib-1.3.1/doc/faq/installing_faq.rst
+++ b/Modules/matplotlib-1.3.1/matplotlib-1.3.1/doc/faq/installing_faq.rst
@@ -107,11 +107,11 @@ Source install from git
 
 Clone the main source using one of::
 
-   git clone git@github.com:matplotlib/matplotlib.git
+   git clone --depth 1 git@github.com:matplotlib/matplotlib.git
 
 or::
 
-   git clone git://github.com/matplotlib/matplotlib.git
+   git clone --depth 1 git://github.com/matplotlib/matplotlib.git
 
 and build and install as usual with::
 
@@ -267,7 +267,7 @@ previous version of MPL was installed (Looks something like
    PREFIX=$HOME
    #branch="release"
    branch="master"
-   git clone git://github.com/matplotlib/matplotlib.git
+   git clone --depth 1 git://github.com/matplotlib/matplotlib.git
    cd matplotlib
    if [ $branch = "release" ]
        then

--- a/Modules/numpy-1.6.2/numpy-1.6.2/doc/source/dev/gitwash/following_latest.rst
+++ b/Modules/numpy-1.6.2/numpy-1.6.2/doc/source/dev/gitwash/following_latest.rst
@@ -18,7 +18,7 @@ Get the local copy of the code
 
 From the command line::
 
-   git clone git://github.com/numpy/numpy.git
+   git clone --depth 1 git://github.com/numpy/numpy.git
 
 You now have a copy of the code tree in the new ``numpy`` directory.
 

--- a/Modules/numpy-1.8.0rc1/numpy-1.8.0rc1/BENTO_BUILD.txt
+++ b/Modules/numpy-1.8.0rc1/numpy-1.8.0rc1/BENTO_BUILD.txt
@@ -2,7 +2,7 @@ No-frill version:
 
 	* Clone bento::
 
-		git clone git://github.com/cournape/Bento.git bento-git
+		git clone --depth 1 git://github.com/cournape/Bento.git bento-git
 
 	* Bootstrap bento::
 
@@ -10,7 +10,7 @@ No-frill version:
 
 	* Download waf >= 1.6.5 from a release (or from git)::
 
-		git clone https://code.google.com/p/waf/
+		git clone --depth 1 https://code.google.com/p/waf/
 
 	* Build numpy with bento:
 

--- a/Modules/numpy-1.8.0rc1/numpy-1.8.0rc1/doc/source/dev/gitwash/following_latest.rst
+++ b/Modules/numpy-1.8.0rc1/numpy-1.8.0rc1/doc/source/dev/gitwash/following_latest.rst
@@ -20,12 +20,12 @@ Get the local copy of the code
 
 From the command line::
 
-   git clone git://github.com/numpy/numpy.git
+   git clone --depth 1 git://github.com/numpy/numpy.git
 
 You now have a copy of the code tree in the new ``numpy`` directory.
 If this doesn't work you can try the alternative read-only url::
 
-   git clone https://github.com/numpy/numpy.git
+   git clone --depth 1 https://github.com/numpy/numpy.git
 
 Updating the code
 =================

--- a/Modules/scipy-0.11.0/scipy-0.11.0/BENTO_BUILD.txt
+++ b/Modules/scipy-0.11.0/scipy-0.11.0/BENTO_BUILD.txt
@@ -2,7 +2,7 @@ No-frill version:
 
 	* Clone bento::
 
-		git clone git://github.com/cournape/Bento.git bento-git
+		git clone --depth 1 git://github.com/cournape/Bento.git bento-git
 	
 	* Bootstrap bento::
 

--- a/Modules/scipy-0.11.0/scipy-0.11.0/HACKING.rst.txt
+++ b/Modules/scipy-0.11.0/scipy-0.11.0/HACKING.rst.txt
@@ -209,7 +209,7 @@ compatibility`_.
 The simplest method is setting up an in-place build.  To create your local git
 repo and do the in-place build::
 
-  $ git clone https://github.com/scipy/scipy.git scipy
+  $ git clone --depth 1 https://github.com/scipy/scipy.git scipy
   $ cd scipy
   $ python setup.py build_ext -i
 

--- a/Modules/scipy-0.11.0/scipy-0.11.0/INSTALL.txt
+++ b/Modules/scipy-0.11.0/scipy-0.11.0/INSTALL.txt
@@ -115,7 +115,7 @@ Development version from Git
 ----------------------------
 Use the command::
 
-  git clone https://github.com/scipy/scipy.git
+  git clone --depth 1 https://github.com/scipy/scipy.git
 
 Before building and installing from git, remove the old installation
 (e.g. in /usr/lib/python2.4/site-packages/scipy or

--- a/Modules/scipy-0.13.0b1/scipy-0.13.0b1/BENTO_BUILD.txt
+++ b/Modules/scipy-0.13.0b1/scipy-0.13.0b1/BENTO_BUILD.txt
@@ -2,7 +2,7 @@ No-frill version:
 
   * Clone bento::
 
-        $ git clone git://github.com/cournape/Bento.git bento
+        $ git clone --depth 1 git://github.com/cournape/Bento.git bento
     
   * Bootstrap bento::
 
@@ -10,7 +10,7 @@ No-frill version:
 
   * Clone Waf::
 
-        $ git clone https://code.google.com/p/waf/ 
+        $ git clone --depth 1 https://code.google.com/p/waf/ 
 
   * Set the WAFDIR environment variable to the base dir of the waf repo you
     just created (in your bash_login for example if you're going to build with

--- a/Modules/scipy-0.13.0b1/scipy-0.13.0b1/HACKING.rst.txt
+++ b/Modules/scipy-0.13.0b1/scipy-0.13.0b1/HACKING.rst.txt
@@ -174,7 +174,7 @@ explained below.
 First fork a copy of the main Scipy repository in Github onto your own
 account and then create your local repository via::
 
-    $ git clone git@github.com:YOURUSERNAME/scipy.git scipy
+    $ git clone --depth 1 git@github.com:YOURUSERNAME/scipy.git scipy
     $ cd scipy
     $ git remote add upstream git://github.com/scipy/scipy.git
 

--- a/Modules/scipy-0.13.0b1/scipy-0.13.0b1/INSTALL.txt
+++ b/Modules/scipy-0.13.0b1/scipy-0.13.0b1/INSTALL.txt
@@ -127,7 +127,7 @@ Development version from Git
 ----------------------------
 Use the command::
 
-  git clone https://github.com/scipy/scipy.git
+  git clone --depth 1 https://github.com/scipy/scipy.git
 
 Before building and installing from git, remove the old installation
 (e.g. in /usr/lib/python2.4/site-packages/scipy or


### PR DESCRIPTION
optimize the git clone using --depth flag in term of size of clone
and also in term's of time taken to fetch the files and commit history
of whole repository .

More detail can be found at blog
https://www.atlassian.com/git/tutorials/big-repositories

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>